### PR TITLE
Rename is_default -> is_primary

### DIFF
--- a/saturnfs/schemas/list.py
+++ b/saturnfs/schemas/list.py
@@ -117,5 +117,5 @@ class Org(DataclassSchema):
     name: str
     email: Optional[str]
     description: str
-    is_default: bool
+    is_primary: bool
     locked: bool


### PR DESCRIPTION
<!-- What is this change, and why is it needed? -->

Missed this when transitioning to the new owner model. Old "default" org is now called "primary"