### PR TITLE
Override default get_file for faster download

### DIFF
--- a/saturnfs/client/file_transfer.py
+++ b/saturnfs/client/file_transfer.py
@@ -1,4 +1,4 @@
-from io import BytesIO
+from io import BufferedWriter
 import os
 from datetime import datetime
 from typing import Any, BinaryIO, List, Optional, Tuple
@@ -79,15 +79,13 @@ class FileTransferClient:
             os.makedirs(dirname, exist_ok=True)
 
         with open(local_path, "wb") as f:
-            self.download_outfile(
-                presigned_download, f, callback=callback, block_size=block_size
-            )
+            self.download_outfile(presigned_download, f, callback=callback, block_size=block_size)
         set_last_modified(local_path, presigned_download.updated_at)
 
     def download_outfile(
         self,
         presigned_download: ObjectStoragePresignedDownload,
-        outfile: BytesIO,
+        outfile: BufferedWriter,
         callback: Optional[Callback] = None,
         block_size: int = settings.S3_MIN_PART_SIZE,
     ):

--- a/saturnfs/client/file_transfer.py
+++ b/saturnfs/client/file_transfer.py
@@ -1,8 +1,10 @@
+from io import BytesIO
 import os
 from datetime import datetime
 from typing import Any, BinaryIO, List, Optional, Tuple
 
 from fsspec import Callback
+from saturnfs import settings
 from saturnfs.client.aws import AWSPresignedClient
 from saturnfs.errors import ExpiredSignature
 from saturnfs.schemas import (
@@ -70,26 +72,37 @@ class FileTransferClient:
         presigned_download: ObjectStoragePresignedDownload,
         local_path: str,
         callback: Optional[Callback] = None,
+        block_size: int = settings.S3_MIN_PART_SIZE,
     ):
         dirname = os.path.dirname(local_path)
         if dirname:
             os.makedirs(dirname, exist_ok=True)
 
+        with open(local_path, "wb") as f:
+            self.download_outfile(
+                presigned_download, f, callback=callback, block_size=block_size
+            )
+        set_last_modified(local_path, presigned_download.updated_at)
+
+    def download_outfile(
+        self,
+        presigned_download: ObjectStoragePresignedDownload,
+        outfile: BytesIO,
+        callback: Optional[Callback] = None,
+        block_size: int = settings.S3_MIN_PART_SIZE,
+    ):
         response = self.aws.get(presigned_download.url, stream=True)
         if callback is not None:
             content_length = response.headers.get("Content-Length")
             callback.set_size(int(content_length) if content_length else None)
 
-        with open(local_path, "wb") as f:
-            for chunk in response.iter_content(None):
-                chunk_size = f.write(chunk)
-                if callback is not None:
-                    callback.relative_update(chunk_size)
+        for chunk in response.iter_content(block_size):
+            bytes_written = outfile.write(chunk)
+            if callback is not None:
+                callback.relative_update(bytes_written)
 
         if callback is not None and callback.size == 0:
             callback.relative_update(0)
-
-        set_last_modified(local_path, presigned_download.updated_at)
 
     def close(self):
         self.aws.close()

--- a/saturnfs/client/file_transfer.py
+++ b/saturnfs/client/file_transfer.py
@@ -1,6 +1,6 @@
-from io import BufferedWriter
 import os
 from datetime import datetime
+from io import BufferedWriter
 from typing import Any, BinaryIO, List, Optional, Tuple
 
 from fsspec import Callback

--- a/saturnfs/client/saturnfs.py
+++ b/saturnfs/client/saturnfs.py
@@ -4,7 +4,7 @@ import os
 import weakref
 from datetime import datetime
 from glob import has_magic
-from io import BytesIO, TextIOWrapper
+from io import BufferedWriter, BytesIO, TextIOWrapper
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union, overload
 from urllib.parse import urlparse
 
@@ -601,7 +601,7 @@ class SaturnFS(AbstractFileSystem):
         rpath: str,
         lpath: str,
         callback: Callback = DEFAULT_CALLBACK,
-        outfile: Optional[BytesIO] = None,
+        outfile: Optional[BufferedWriter] = None,
         **kwargs,
     ):
         remote = ObjectStorage.parse(rpath)

--- a/saturnfs/client/saturnfs.py
+++ b/saturnfs/client/saturnfs.py
@@ -604,7 +604,12 @@ class SaturnFS(AbstractFileSystem):
         outfile: Optional[BytesIO] = None,
         **kwargs,
     ):
-        super().get_file(rpath, lpath, callback=callback, outfile=outfile, **kwargs)
+        remote = ObjectStorage.parse(rpath)
+        download = self.object_storage_client.download_file(remote)
+        if outfile is not None:
+            self.file_transfer.download_outfile(download, outfile, callback=callback, **kwargs)
+        else:
+            self.file_transfer.download(download, lpath, callback=callback, **kwargs)
 
     def get_bulk(self, rpaths: List[str], lpaths: List[str], callback: Callback = DEFAULT_CALLBACK):
         callback.set_size(len(lpaths))


### PR DESCRIPTION
<!-- What is this change, and why is it needed? -->

Replacing the default get_file implementation to use file streaming (instead of requesting in chunks). Same utilities used for get_bulk