### PR TITLE
Reference presigned download size with fs.open and validate cached file listings

### DIFF
--- a/saturnfs/client/aws.py
+++ b/saturnfs/client/aws.py
@@ -35,7 +35,7 @@ class AWSPresignedClient:
         if not response.ok:
             if self.is_expired(response):
                 raise ExpiredSignature()
-            raise SaturnError(response.text, status=500)
+            raise SaturnError(response.text, status=response.status_code)
 
     def is_expired(self, response: Response) -> bool:
         if response.status_code == 403:

--- a/saturnfs/client/file_transfer.py
+++ b/saturnfs/client/file_transfer.py
@@ -79,10 +79,10 @@ class FileTransferClient:
             os.makedirs(dirname, exist_ok=True)
 
         with open(local_path, "wb") as f:
-            self.download_outfile(presigned_download, f, callback=callback, block_size=block_size)
+            self.download_to_writer(presigned_download, f, callback=callback, block_size=block_size)
         set_last_modified(local_path, presigned_download.updated_at)
 
-    def download_outfile(
+    def download_to_writer(
         self,
         presigned_download: ObjectStoragePresignedDownload,
         outfile: BufferedWriter,

--- a/saturnfs/client/saturnfs.py
+++ b/saturnfs/client/saturnfs.py
@@ -790,6 +790,7 @@ class SaturnFile(AbstractBufferedFile):
             presigned_download = self._presign_download()
             if size is None:
                 size = presigned_download.size
+        self.size = size
 
         super().__init__(
             fs,

--- a/saturnfs/client/saturnfs.py
+++ b/saturnfs/client/saturnfs.py
@@ -726,7 +726,7 @@ class SaturnFS(AbstractFileSystem):
 
         super().invalidate_cache(path)
 
-    def validate_cache(self, path: str, size: int, updated_at: datetime) -> bool:
+    def validate_cache(self, path: str, size: int, updated_at: datetime):
         """
         Compare cached file results against known values to determine if the cache
         should be invalidated.
@@ -735,8 +735,6 @@ class SaturnFS(AbstractFileSystem):
         if info is not None:
             if info.size != size or info.updated_at != updated_at:
                 self.invalidate_cache(path)
-                return True
-        return False
 
 
 class SaturnFile(AbstractBufferedFile):

--- a/saturnfs/client/saturnfs.py
+++ b/saturnfs/client/saturnfs.py
@@ -37,11 +37,11 @@ class SaturnFS(AbstractFileSystem):
     blocksize = settings.S3_MIN_PART_SIZE
     protocol = "sfs"
 
-    def __init__(self):
+    def __init__(self, *args, **storage_options):
         self.object_storage_client = ObjectStorageClient()
         self.file_transfer = FileTransferClient()
         weakref.finalize(self, self.close)
-        super().__init__()
+        super().__init__(*args, **storage_options)
 
     @property
     def fsid(self) -> str:
@@ -779,6 +779,8 @@ class SaturnFile(AbstractBufferedFile):
         elif block_size > settings.S3_MAX_PART_SIZE:
             raise SaturnError(f"Max block size: {settings.S3_MIN_PART_SIZE}")
 
+        self.fs = fs
+        self.path = path
         self.remote = ObjectStorage.parse(path)
         if mode == "rb":
             # Prefetch download URL and size to skip the extra info request

--- a/saturnfs/schemas/download.py
+++ b/saturnfs/schemas/download.py
@@ -25,6 +25,7 @@ class ObjectStorageBulkDownload(DataclassSchema):
 @marshmallow_dataclass.dataclass
 class ObjectStoragePresignedDownload(DataclassSchema):
     file_path: str
+    size: int
     updated_at: datetime
     url: str
 


### PR DESCRIPTION
<!-- What is this change, and why is it needed? -->

Avoid using potentially stale cached list values when determining download size of a file in `SaturnFile` opened with `fs.open(...)`. If the file has been updated by a different client then the cache will no longer be accurate. Saturn presigned download includes info about the file such as updated_at and size, so it can get all the info it needs with one API call.

Since we have this info readily available, `SaturnFile` will now also validate the filesystem's cache when a file is downloaded. If the cached values don't match, then they are invalidated so the next list will be accurate.