### PR TITLE
Parallel chunked download

### DIFF
--- a/environment.test.yaml
+++ b/environment.test.yaml
@@ -4,6 +4,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.7
+  - click<8.1.4
   - pip
   - pip:
       - black>=20.8b1

--- a/environment.yaml
+++ b/environment.yaml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.7
-  - click
+  - click<8.1.4
   - requests
   - marshmallow>=3.10.0,<4.0.0
   - marshmallow-dataclass

--- a/saturnfs/cli/commands.py
+++ b/saturnfs/cli/commands.py
@@ -283,8 +283,8 @@ def exists(path: str):
 
 
 @cli.command("usage")
-@click.option("--owner", type=str, help="Owner name '<org>/<identity>'")
-def storage_usage(owner_name: Optional[str] = None):
+@click.option("--owner", type=str, default=None, help="Owner name '<org>/<identity>'")
+def storage_usage(owner: Optional[str] = None):
     sfs = SaturnFS()
-    usage = sfs.usage(owner_name)
+    usage = sfs.usage(owner)
     click.echo(json.dumps(usage.dump(), indent=2))

--- a/saturnfs/client/aws.py
+++ b/saturnfs/client/aws.py
@@ -15,9 +15,15 @@ class AWSPresignedClient:
         self.session = Session()
 
     def get(
-        self, url: str, headers: Optional[Dict[str, str]] = None, stream: bool = False
+        self,
+        url: str,
+        headers: Optional[Dict[str, str]] = None,
+        stream: bool = False,
+        session: Optional[Session] = None,
     ) -> Response:
-        response = self.session.get(url, headers=headers, stream=stream)
+        if not session:
+            session = self.session
+        response = session.get(url, headers=headers, stream=stream)
         self.check_errors(response)
         return response
 
@@ -26,8 +32,11 @@ class AWSPresignedClient:
         url: str,
         data: Optional[Any] = None,
         headers: Optional[Dict[str, str]] = None,
+        session: Optional[Session] = None,
     ) -> Response:
-        response = self.session.put(url, data, headers=headers)
+        if not session:
+            session = self.session
+        response = session.put(url, data, headers=headers)
         self.check_errors(response)
         return response
 

--- a/saturnfs/client/file_transfer.py
+++ b/saturnfs/client/file_transfer.py
@@ -83,13 +83,20 @@ class FileTransferClient:
         local_path: str,
         callback: Optional[Callback] = None,
         block_size: int = settings.S3_MIN_PART_SIZE,
+        max_workers: int = 10,
     ):
         dirname = os.path.dirname(local_path)
         if dirname:
             os.makedirs(dirname, exist_ok=True)
 
-        if presigned_download.size >= 5 * settings.S3_MIN_PART_SIZE:
-            self._parallel_download(presigned_download, local_path, block_size, callback=callback)
+        if max_workers > 1 and presigned_download.size >= 3 * block_size:
+            self._parallel_download(
+                presigned_download,
+                local_path,
+                block_size,
+                callback=callback,
+                max_workers=max_workers,
+            )
         else:
             with open(local_path, "wb") as f:
                 self.download_to_writer(

--- a/saturnfs/client/file_transfer.py
+++ b/saturnfs/client/file_transfer.py
@@ -1,9 +1,17 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import heapq
+from math import ceil, remainder
 import os
 from datetime import datetime
 from io import BufferedWriter
-from typing import Any, BinaryIO, List, Optional, Tuple
+from queue import Full, PriorityQueue, Queue
+from threading import Thread
+from typing import Any, BinaryIO, Dict, List, Optional, Tuple
 
 from fsspec import Callback
+from requests import Session
 from saturnfs import settings
 from saturnfs.client.aws import AWSPresignedClient
 from saturnfs.errors import ExpiredSignature
@@ -13,6 +21,7 @@ from saturnfs.schemas import (
     ObjectStoragePresignedUpload,
 )
 from saturnfs.schemas.upload import ObjectStoragePresignedPart
+from saturnfs.utils import byte_range_header
 
 
 class FileTransferClient:
@@ -22,6 +31,7 @@ class FileTransferClient:
 
     def __init__(self):
         self.aws = AWSPresignedClient()
+        self.max_workers = 10
 
     def upload(
         self, local_path: str, presigned_upload: ObjectStoragePresignedUpload, file_offset: int = 0
@@ -78,8 +88,13 @@ class FileTransferClient:
         if dirname:
             os.makedirs(dirname, exist_ok=True)
 
-        with open(local_path, "wb") as f:
-            self.download_to_writer(presigned_download, f, callback=callback, block_size=block_size)
+        # TODO: Pick a reasonable thing here
+        allow_parallel = True
+        if allow_parallel and presigned_download.size >= 5 * settings.S3_MIN_PART_SIZE:
+            self._parallel_download(presigned_download, local_path, block_size, callback=callback)
+        else:
+            with open(local_path, "wb") as f:
+                self.download_to_writer(presigned_download, f, callback=callback, block_size=block_size)
         set_last_modified(local_path, presigned_download.updated_at)
 
     def download_to_writer(
@@ -88,8 +103,10 @@ class FileTransferClient:
         outfile: BufferedWriter,
         callback: Optional[Callback] = None,
         block_size: int = settings.S3_MIN_PART_SIZE,
+        stream: bool = True,
+        **kwargs,
     ):
-        response = self.aws.get(presigned_download.url, stream=True)
+        response = self.aws.get(presigned_download.url, stream=stream, **kwargs)
         if callback is not None:
             content_length = response.headers.get("Content-Length")
             callback.set_size(int(content_length) if content_length else None)
@@ -101,6 +118,145 @@ class FileTransferClient:
 
         if callback is not None and callback.size == 0:
             callback.relative_update(0)
+        response.close()
+
+    def _parallel_download(self, presigned_download: ObjectStoragePresignedDownload, local_path: str, block_size: int, callback: Optional[Callback] = None):
+        filename = os.path.basename(local_path)
+        parent_dir = os.path.dirname(local_path)
+        tmp_dir = os.path.join(parent_dir, f".saturnfs_{filename}")
+        os.makedirs(tmp_dir, exist_ok=True)
+
+        num_chunks = ceil(presigned_download.size / block_size)
+        last_chunk_size = presigned_download.size % block_size
+        num_workers = min(num_chunks, self.max_workers)
+
+        download_queue: Queue[Optional[DownloadChunk]] = Queue(2 * num_workers)
+        completed_queue: PriorityQueue[DownloadChunk] = PriorityQueue()
+
+        producer_kwargs = {
+            "download_queue": download_queue,
+            "tmp_dir": tmp_dir,
+            "block_size": block_size,
+            "num_chunks": num_chunks,
+            "last_chunk_size": last_chunk_size,
+            "num_workers": num_workers,
+        }
+        worker_kwargs = {
+            "presigned_download": presigned_download,
+            "download_queue": download_queue,
+            "completed_queue": completed_queue,
+        }
+
+        Thread(target=self._download_producer, kwargs=producer_kwargs, daemon=True).start()
+        for _ in range(num_workers):
+            Thread(target=self._download_worker, kwargs=worker_kwargs, daemon=True).start()
+        self._reconstruct(completed_queue, local_path, num_chunks, callback=callback)
+        os.rmdir(tmp_dir)
+
+    def _download_producer(
+        self,
+        download_queue: Queue[DownloadChunk],
+        tmp_dir: str,
+        block_size: int,
+        num_chunks: int,
+        last_chunk_size: int,
+        num_workers: int,
+    ):
+        # TODO: Handle resumed download
+        for i in range(num_chunks):
+            if i == num_chunks - 1 and last_chunk_size:
+                chunk_size = last_chunk_size
+            else:
+                chunk_size = block_size
+
+            part_number = i + 1
+            tmp_path = os.path.join(tmp_dir, f"part_{part_number}")
+            chunk = DownloadChunk(part_number=part_number, chunk_size=chunk_size, tmp_path=tmp_path)
+            download_queue.put(chunk)
+        # Wait for workers to finish processing all chunks
+        download_queue.join()
+
+        # Signal shutdown to download workers
+        for i in range(num_workers):
+            download_queue.put(None)
+
+    def _download_worker(
+        self,
+        presigned_download: ObjectStoragePresignedDownload,
+        download_queue: Queue[DownloadChunk],
+        completed_queue: PriorityQueue[DownloadChunk],
+    ):
+        # TODO: How to handle URL expiration?
+        session = Session()
+        while True:
+            chunk = download_queue.get()
+            if chunk is None:
+                # No more download tasks. Put another sentinal
+                # on the queue just in case, then break.
+                try:
+                    download_queue.put_nowait(None)
+                except Full:
+                    pass
+                finally:
+                    break
+
+            start = (chunk.part_number - 1) * chunk.chunk_size
+            end = start + chunk.chunk_size
+            if end > presigned_download.size:
+                end = presigned_download.size
+            headers = byte_range_header(start, end)
+
+            with open(chunk.tmp_path, "wb") as f:
+                self.download_to_writer(
+                    presigned_download, f, headers=headers, session=session
+                )
+
+            download_queue.task_done()
+            completed_queue.put(chunk)
+        session.close()
+
+    def _reconstruct(
+        self,
+        completed_queue: PriorityQueue[DownloadChunk],
+        local_path: str,
+        num_chunks: int,
+        next_part: int = 1,
+        callback: Optional[Callback] = None,
+    ):
+        done = False
+        heap: List[DownloadChunk] = []
+
+        def _mv(tmp_path: str, f: BufferedWriter):
+            with open(tmp_path, "rb") as tmp:
+                f.write(tmp.read())
+            os.remove(tmp_path)
+
+        with open(local_path, "wb") as f:
+            done = False
+            while not done:
+                # Get the next completed chunk
+                chunk = completed_queue.get()
+                if callback is not None:
+                    callback.relative_update(chunk.chunk_size)
+
+                if chunk.part_number == next_part:
+                    # Append chunk to the final file
+                    _mv(chunk.tmp_path, f)
+                    if next_part == num_chunks:
+                        done = True
+                    else:
+                        # Check if the next part(s) are already in the heap
+                        next_part += 1
+                        while len(heap) > 0 and heap[0].part_number == next_part:
+                            chunk = heapq.heappop(heap)
+                            _mv(chunk.tmp_path, f)
+                            if next_part == num_chunks:
+                                done = True
+                                break
+                            next_part += 1
+                else:
+                    # Push chunk onto the heap to wait for all previous chunks to complete
+                    heapq.heappush(heap, chunk)
 
     def close(self):
         self.aws.close()
@@ -129,6 +285,19 @@ class FileLimiter:
         data = self.file.read(min(amount, bytes_remaining))
         self.bytes_read += len(data)
         return data
+
+
+@dataclass
+class DownloadChunk:
+    """
+    Stores information for parallel chunk download
+    """
+    part_number: int
+    chunk_size: int
+    tmp_path: str
+
+    def __lt__(self, other: DownloadChunk):
+        return self.part_number < other.part_number
 
 
 def set_last_modified(local_path: str, last_modified: datetime):

--- a/saturnfs/client/file_transfer.py
+++ b/saturnfs/client/file_transfer.py
@@ -9,7 +9,7 @@ from io import BufferedWriter
 from math import ceil
 from queue import Full, PriorityQueue, Queue
 from threading import Thread
-from typing import Any, BinaryIO, Dict, List, Optional, Tuple
+from typing import Any, BinaryIO, List, Optional, Tuple
 
 from fsspec import Callback
 from requests import Session
@@ -212,8 +212,7 @@ class FileTransferClient:
                     download_queue.put_nowait(None)
                 except Full:
                     pass
-                finally:
-                    break
+                break
 
             start = (chunk.part_number - 1) * block_size
             end = start + chunk.chunk_size

--- a/saturnfs/client/file_transfer.py
+++ b/saturnfs/client/file_transfer.py
@@ -163,7 +163,7 @@ class FileTransferClient:
 
     def _download_producer(
         self,
-        download_queue: Queue[DownloadChunk],
+        download_queue: Queue[Optional[DownloadChunk]],
         tmp_dir: str,
         block_size: int,
         num_chunks: int,

--- a/saturnfs/client/saturnfs.py
+++ b/saturnfs/client/saturnfs.py
@@ -30,6 +30,8 @@ from saturnfs.schemas.upload import (
 from saturnfs.schemas.usage import ObjectStorageUsageResults
 from typing_extensions import Literal
 
+from saturnfs.utils import byte_range_header
+
 DEFAULT_CALLBACK = NoOpCallback()
 
 
@@ -884,7 +886,7 @@ class SaturnFile(AbstractBufferedFile):
 
     def _fetch_range(self, start: int, end: int):
         presigned_download = self.presigned_download or self._presign_download()
-        headers = {"Range": f"bytes={start}-{end - 1}"}
+        headers = byte_range_header(start, end)
         try:
             response = self.fs.file_transfer.aws.get(presigned_download.url, headers=headers)
         except ExpiredSignature:

--- a/saturnfs/client/saturnfs.py
+++ b/saturnfs/client/saturnfs.py
@@ -28,9 +28,8 @@ from saturnfs.schemas.upload import (
     ObjectStorageUploadInfo,
 )
 from saturnfs.schemas.usage import ObjectStorageUsageResults
-from typing_extensions import Literal
-
 from saturnfs.utils import byte_range_header
+from typing_extensions import Literal
 
 DEFAULT_CALLBACK = NoOpCallback()
 

--- a/saturnfs/utils.py
+++ b/saturnfs/utils.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Dict
 
 
 class Units(int, Enum):
@@ -16,3 +17,10 @@ def human_readable_format(size: float):
     formatted = f"{size:.2f}"
     formatted = formatted.rstrip("0").rstrip(".")
     return f"{formatted} {unit}"
+
+
+def byte_range_header(start: int, end: int) -> Dict[str, str]:
+    """
+    HTTP byte range header with non-inclusive end
+    """
+    return {"Range": f"bytes={start}-{end - 1}"}


### PR DESCRIPTION
<!-- What is this change, and why is it needed? -->

Download large files in chunks to a temporary directory, then reconstruct the file from there. Allows for much faster download of big files, without using much more disk space or memory.