### PR TITLE
Fix typing for pylance

### DIFF
--- a/saturnfs/client/saturnfs.py
+++ b/saturnfs/client/saturnfs.py
@@ -11,7 +11,7 @@ from urllib.parse import urlparse
 from fsspec.caching import BaseCache
 from fsspec.callbacks import Callback, NoOpCallback
 from fsspec.implementations.local import LocalFileSystem, make_path_posix
-from fsspec.spec import AbstractBufferedFile, AbstractFileSystem
+from fsspec.spec import AbstractBufferedFile, AbstractFileSystem, _Cached
 from fsspec.utils import other_paths
 from saturnfs import settings
 from saturnfs.client.file_transfer import FileTransferClient
@@ -34,7 +34,14 @@ from typing_extensions import Literal
 DEFAULT_CALLBACK = NoOpCallback()
 
 
-class SaturnFS(AbstractFileSystem):
+class _CachedTyped(_Cached):
+    # Add typing to the metaclass to get around an issue with pylance
+    # https://github.com/microsoft/pylance-release/issues/4384
+    def __call__(cls, *args, **kwargs) -> SaturnFS:
+        return super().__call__(*args, **kwargs)
+
+
+class SaturnFS(AbstractFileSystem, metaclass=_CachedTyped):
     blocksize = settings.S3_MIN_PART_SIZE
     protocol = "sfs"
 

--- a/saturnfs/client/saturnfs.py
+++ b/saturnfs/client/saturnfs.py
@@ -37,11 +37,11 @@ DEFAULT_CALLBACK = NoOpCallback()
 class _CachedTyped(_Cached):
     # Add typing to the metaclass to get around an issue with pylance
     # https://github.com/microsoft/pylance-release/issues/4384
-    def __call__(cls, *args, **kwargs) -> SaturnFS:
+    def __call__(cls, *args, **kwargs) -> SaturnFS:  # pylint: disable=no-self-argument
         return super().__call__(*args, **kwargs)
 
 
-class SaturnFS(AbstractFileSystem, metaclass=_CachedTyped):
+class SaturnFS(AbstractFileSystem, metaclass=_CachedTyped):  # pylint: disable=invalid-metaclass
     blocksize = settings.S3_MIN_PART_SIZE
     protocol = "sfs"
 


### PR DESCRIPTION
<!-- What is this change, and why is it needed? -->

A change in behavior for pylance resulted in objects created by the SaturnFS `__init__` being typed `Any` instead of `SaturnFS`.
https://github.com/microsoft/pylance-release/issues/4384

By adding a type to the `__call__` method of the fsspec metaclass, pylance (and other static type checkers) can again correctly determine the type of objects created from init.
