### PR TITLE
Fetch starting from next unsigned part, not next part to upload

### DIFF
--- a/saturnfs/client/saturnfs.py
+++ b/saturnfs/client/saturnfs.py
@@ -942,7 +942,7 @@ class SaturnFile(AbstractBufferedFile):
             remaining_presigned = num_presigned - num_completed
             min_required = num_parts - remaining_presigned
             self._presign_upload(
-                num_completed + 1, min_required, final=final, last_part_size=last_part_size
+                num_presigned + 1, min_required, final=final, last_part_size=last_part_size
             )
 
     def _presign_upload(


### PR DESCRIPTION
<!-- What is this change, and why is it needed? -->

Bug found when using fsspec interface to upload files with huggingface transformers.

Need to fetch parts starting from the next unsigned number, not the next number that needs to be uploaded. Typically at this point `num_presigned == num_completed`, but if the chunk being uploaded is larger than the size of the remaining number of chunks, this is not the case and would result in signing mulitple parts with the same part number.