### PR TITLE
saturnfs rsync support

### DIFF
--- a/saturnfs/client/saturnfs.py
+++ b/saturnfs/client/saturnfs.py
@@ -915,12 +915,13 @@ class SaturnFile(AbstractBufferedFile):
             num_parts = 1
             remainder = 0
 
-        if final and remainder > 0:
+        last_part_size: Optional[int] = None
+        if final and (remainder > 0 or num_parts == 0):
+            last_part_size = remainder
             num_parts += 1
 
         num_completed = len(self.completed_upload_parts)
         num_presigned = len(self.presigned_upload_parts)
-        last_part_size = remainder if final and remainder > 0 else None
         total_parts = num_completed + num_parts
 
         if refresh:

--- a/saturnfs/schemas/base.py
+++ b/saturnfs/schemas/base.py
@@ -38,3 +38,6 @@ class DataclassSchema:
 
     def __getitem__(self, key):
         return getattr(self, key)
+
+    def __setitem__(self, key, value):
+        setattr(self, key, value)

--- a/saturnfs/schemas/list.py
+++ b/saturnfs/schemas/list.py
@@ -59,13 +59,22 @@ class ObjectStorageInfo(DataclassSchema):
     created_at: Optional[datetime] = field(default=None)
     updated_at: Optional[datetime] = field(default=None)
 
+    _name: Optional[str] = field(init=False, default=None)
+
     @property
     def is_dir(self) -> bool:
         return self.type == "directory"
 
     @property
     def name(self) -> str:
+        if self._name is not None:
+            return self._name
         return full_path(self.owner_name, self.file_path)
+
+    @name.setter
+    def name(self, value):
+        # Fsspec generic rsync needs to override name
+        self._name = value
 
     def __fspath__(self) -> str:
         return self.name

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ install_requires = [
     "requests",
     "marshmallow>=3.10.0,<4.0.0",
     "marshmallow-dataclass",
-    "fsspec"
+    "fsspec",
 ]
 
 
@@ -25,8 +25,8 @@ setup(
         "console_scripts": [
             "saturnfs=saturnfs.cli.main:entrypoint",
         ],
-        'fsspec.specs': [
-            'sfs=saturnfs.SaturnFS',
+        "fsspec.specs": [
+            "sfs=saturnfs.SaturnFS",
         ],
     },
     url="https://saturncloud.io/",


### PR DESCRIPTION
<!-- What is this change, and why is it needed? -->

Couple of things needed for fsspec rsync to work
- Allow overwriting dataclass objs with key assignment. Rsync expects to be able to write to "name"
- Handle files created with `open` that are zero bytes (previously did not account for final part size of 0)