### PR TITLE
Pin fsspec to known working version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ install_requires = [
     "requests",
     "marshmallow>=3.10.0,<4.0.0",
     "marshmallow-dataclass",
-    "fsspec",
+    "fsspec==2023.1.0",
 ]
 
 


### PR DESCRIPTION
<!-- What is this change, and why is it needed? -->

Some recent changes in fsspec break saturnfs. Pinning to a known working version for now.