### PR TITLE
rsync local

### DIFF
--- a/saturnfs/client/saturnfs.py
+++ b/saturnfs/client/saturnfs.py
@@ -582,7 +582,9 @@ class SaturnFS(AbstractFileSystem, metaclass=_CachedTyped):  # pylint: disable=i
                 raise SaturnError("File is smaller than the given size")
             callback.set_size(size)
 
-        if block_size is None and size > 10 * settings.S3_MIN_PART_SIZE:
+        if block_size is not None and block_size > size:
+            block_size = size
+        elif block_size is None and size > 10 * settings.S3_MIN_PART_SIZE:
             if size / settings.S3_MAX_NUM_PARTS > settings.S3_MIN_PART_SIZE:
                 block_size = settings.S3_MAX_PART_SIZE
             else:

--- a/saturnfs/client/saturnfs.py
+++ b/saturnfs/client/saturnfs.py
@@ -29,7 +29,7 @@ from saturnfs.errors import ExpiredSignature, SaturnError
 from saturnfs.schemas import ObjectStorage, ObjectStoragePrefix
 from saturnfs.schemas.download import ObjectStoragePresignedDownload
 from saturnfs.schemas.list import ObjectStorageInfo
-from saturnfs.schemas.reference import BulkObjectStorage
+from saturnfs.schemas.reference import BulkObjectStorage, full_path
 from saturnfs.schemas.upload import (
     ObjectStorageCompletePart,
     ObjectStoragePresignedPart,
@@ -772,7 +772,7 @@ class SaturnFS(AbstractFileSystem, metaclass=_CachedTyped):  # pylint: disable=i
                 )
                 self.object_storage_client.delete_bulk(bulk)
                 for path in bulk.file_paths:
-                    self.invalidate_cache(path)
+                    self.invalidate_cache(full_path(owner_name, path))
                 i += settings.OBJECT_STORAGE_MAX_LIST_COUNT
 
     def rsync(self, source: str, destination: str, delete_missing: bool = False, **kwargs):


### PR DESCRIPTION
<!-- What is this change, and why is it needed? -->

fsspec rsync uses the file abstraction to copy between filesystems. This is less efficient for saturnfs, which can do upload/download in parallelized chunks. By special casing transfers to/from local filesystem it is much easier to handle parallelizing the transfer.