### PR TITLE
error handling

### DIFF
--- a/saturnfs/client/aws.py
+++ b/saturnfs/client/aws.py
@@ -3,6 +3,7 @@ from xml.etree import ElementTree
 
 from requests import Response, Session
 from saturnfs.errors import ExpiredSignature, SaturnError
+from saturnfs.utils import requests_session
 
 
 class AWSPresignedClient:
@@ -12,7 +13,7 @@ class AWSPresignedClient:
     """
 
     def __init__(self) -> None:
-        self.session = Session()
+        self.session = requests_session()
 
     def get(
         self,

--- a/saturnfs/client/file_transfer.py
+++ b/saturnfs/client/file_transfer.py
@@ -13,7 +13,6 @@ from threading import Event, Thread
 from typing import Any, BinaryIO, Dict, Iterable, List, Optional, Tuple, Union
 
 from fsspec import Callback
-from requests import Session
 from saturnfs import settings
 from saturnfs.client.aws import AWSPresignedClient
 from saturnfs.errors import ExpiredSignature
@@ -23,7 +22,7 @@ from saturnfs.schemas import (
     ObjectStoragePresignedUpload,
 )
 from saturnfs.schemas.upload import ObjectStoragePresignedPart
-from saturnfs.utils import byte_range_header
+from saturnfs.utils import byte_range_header, requests_session
 
 
 class FileTransferClient:
@@ -368,7 +367,7 @@ class ParallelDownloader:
         Pull chunks from the download queue, and write the associated byte range to a temp file.
         Push completed chunk onto the completed queue to be reconstructed.
         """
-        with Session() as session:
+        with requests_session() as session:
             while True:
                 part = self.download_queue.get()
                 if part is None:
@@ -500,7 +499,7 @@ class ParallelUploader:
                     return False
 
     def _worker(self):
-        with Session() as session:
+        with requests_session() as session:
             while True:
                 chunk = self.upload_queue.get()
                 if chunk is None:

--- a/saturnfs/client/file_transfer.py
+++ b/saturnfs/client/file_transfer.py
@@ -379,12 +379,12 @@ class ParallelDownloader:
                         pass
                     break
 
-                if self.disk_buffer:
-                    buffer = tempfile.TemporaryFile(mode="w+b")
-                else:
-                    buffer = BytesIO()
-
                 try:
+                    if self.disk_buffer:
+                        buffer = tempfile.TemporaryFile(mode="w+b")
+                    else:
+                        buffer = BytesIO()
+
                     self.file_transfer._download_to_writer(
                         part.url, buffer, headers=part.headers, session=session
                     )

--- a/saturnfs/client/object_storage.py
+++ b/saturnfs/client/object_storage.py
@@ -32,6 +32,7 @@ from saturnfs.schemas.upload import (
     ObjectStorageUploadList,
 )
 from saturnfs.schemas.usage import ObjectStorageUsageResults
+from saturnfs.utils import requests_session
 
 
 class ObjectStorageClient:
@@ -45,10 +46,12 @@ class ObjectStorageClient:
         backoff_factor: float = 0.1,
         retry_statuses: Collection[int] = frozenset([409, 423]),
     ):
-        retry = Retry(retries, backoff_factor=backoff_factor, status_forcelist=retry_statuses)
-        self.session = Session()
-        self.session.headers["Authorization"] = f"token {settings.SATURN_TOKEN}"
-        self.session.mount("http", HTTPAdapter(max_retries=retry))
+        self.session = requests_session(
+            retries=retries,
+            backoff_factor=backoff_factor,
+            status_forcelist=retry_statuses,
+            headers={"Authorization": f"token {settings.SATURN_TOKEN}"}
+        )
 
     def start_upload(
         self,

--- a/saturnfs/client/object_storage.py
+++ b/saturnfs/client/object_storage.py
@@ -1,7 +1,5 @@
 from typing import Collection, Iterable, List, Optional
 
-from requests import Session
-from requests.adapters import HTTPAdapter, Retry
 from saturnfs import settings
 from saturnfs.api.delete import BulkDeleteAPI, DeleteAPI
 from saturnfs.api.download import BulkDownloadAPI, DownloadAPI
@@ -50,7 +48,7 @@ class ObjectStorageClient:
             retries=retries,
             backoff_factor=backoff_factor,
             status_forcelist=retry_statuses,
-            headers={"Authorization": f"token {settings.SATURN_TOKEN}"}
+            headers={"Authorization": f"token {settings.SATURN_TOKEN}"},
         )
 
     def start_upload(

--- a/saturnfs/utils.py
+++ b/saturnfs/utils.py
@@ -1,7 +1,8 @@
 from enum import Enum
+from typing import Dict, Optional
+
 from requests import Session
 from requests.adapters import HTTPAdapter, Retry
-from typing import Dict, Optional
 
 
 class Units(int, Enum):

--- a/saturnfs/utils.py
+++ b/saturnfs/utils.py
@@ -1,5 +1,7 @@
 from enum import Enum
-from typing import Dict
+from requests import Session
+from requests.adapters import HTTPAdapter, Retry
+from typing import Dict, Optional
 
 
 class Units(int, Enum):
@@ -24,3 +26,17 @@ def byte_range_header(start: int, end: int) -> Dict[str, str]:
     HTTP byte range header with non-inclusive end
     """
     return {"Range": f"bytes={start}-{end - 1}"}
+
+
+def requests_session(
+    retries: int = 10,
+    backoff_factor: float = 0.1,
+    headers: Optional[Dict[str, str]] = None,
+    **kwargs,
+) -> Session:
+    retry = Retry(total=retries, backoff_factor=backoff_factor, **kwargs)
+    session = Session()
+    session.mount("http", HTTPAdapter(max_retries=retry))
+    if headers:
+        session.headers.update(headers)
+    return session


### PR DESCRIPTION
<!-- What is this change, and why is it needed? -->

Add retry handler for standard connection errors on aws client.
Catch unexpected exceptions in parallel workers and gracefully shutdown to avoid hanging indefinitely