### PR TITLE
Add callback on rsync CLI command

### DIFF
--- a/saturnfs/client/file_transfer.py
+++ b/saturnfs/client/file_transfer.py
@@ -580,7 +580,6 @@ class ParallelUploader:
             completed_part = self.completed_queue.get()
             if isinstance(completed_part, UploadStop):
                 # End of upload detected
-                # Producer only puts None on the queue when all workers are done
                 uploads_finished = not completed_part.error
                 self.completed_queue.task_done()
                 break

--- a/saturnfs/client/file_transfer.py
+++ b/saturnfs/client/file_transfer.py
@@ -486,7 +486,7 @@ class ParallelUploader:
         Thread(target=self._producer, kwargs={"chunks": chunks}, daemon=True).start()
         return first_chunk.part.part_number
 
-    def _producer(self, chunks: Iterable[UploadChunk]) -> int:
+    def _producer(self, chunks: Iterable[UploadChunk]):
         # Iterate chunks onto the upload_queue until completed or error detected
         all_chunks_read: bool = False
         for chunk in chunks:

--- a/saturnfs/client/saturnfs.py
+++ b/saturnfs/client/saturnfs.py
@@ -1257,13 +1257,9 @@ class SaturnGenericFilesystem(GenericFileSystem):
         if self._is_local(proto1) and self._is_saturnfs(proto2):
             if blocksize < settings.S3_MIN_PART_SIZE:
                 blocksize = settings.S3_MIN_PART_SIZE
-            return self.sfs.put_file(
-                path1, path2, block_size=blocksize, **kwargs
-            )
+            return self.sfs.put_file(path1, path2, block_size=blocksize, **kwargs)
         elif self._is_saturnfs(proto1) and self._is_local(proto2):
-            return self.sfs.get_file(
-                path1, path2, block_size=blocksize, **kwargs
-            )
+            return self.sfs.get_file(path1, path2, block_size=blocksize, **kwargs)
 
         return await super()._cp_file(url, url2, blocksize, **kwargs)
 


### PR DESCRIPTION
<!-- What is this change, and why is it needed? -->

Add callback to rsync CLI command. Special case callback handling in SaturnGenericFilesystem for FileOpCallback to get proper branch handling, since the default _copy implementation for AsyncFilesystem does not branch.

Refactoring the parallel uploader to begin collecting and reporting completed upload chunks immediately so the callback is more responsive.