### PR TITLE
rsync threadpool for batched file uploads

### DIFF
--- a/saturnfs/cli/commands.py
+++ b/saturnfs/cli/commands.py
@@ -195,7 +195,7 @@ def delete(path: str, recursive: bool):
     "--max-file-workers",
     type=int,
     default=1,
-    help="Maximum number of threads to run per file for parallel chunk upload/download"
+    help="Maximum number of threads to run per file for parallel chunk upload/download",
 )
 def rsync(
     source_path: str,

--- a/saturnfs/cli/commands.py
+++ b/saturnfs/cli/commands.py
@@ -185,7 +185,25 @@ def delete(path: str, recursive: bool):
     default=False,
     help="Delete paths from the destination that are missing in the source",
 )
-def rsync(source_path: str, destination_path: str, delete_missing: bool, quiet: bool):
+@click.option(
+    "--max-batch-workers",
+    type=int,
+    default=settings.SATURNFS_DEFAULT_MAX_WORKERS,
+    help="Maximum number of threads to run for batched file uploads",
+)
+@click.option(
+    "--max-file-workers",
+    type=int,
+    default=1,
+    help="Maximum number of threads to run per file for parallel chunk upload/download"
+)
+def rsync(
+    source_path: str,
+    destination_path: str,
+    delete_missing: bool,
+    quiet: bool,
+    **kwargs,
+):
     """
     Recursively sync files between two directory trees
     """
@@ -202,7 +220,9 @@ def rsync(source_path: str, destination_path: str, delete_missing: bool, quiet: 
         operation = file_op(src_is_local, dst_is_local)
         callback = FileOpCallback(operation=operation)
 
-    sfs.rsync(source_path, destination_path, delete_missing=delete_missing, callback=callback)
+    sfs.rsync(
+        source_path, destination_path, delete_missing=delete_missing, callback=callback, **kwargs
+    )
 
 
 @cli.command("ls")

--- a/saturnfs/client/saturnfs.py
+++ b/saturnfs/client/saturnfs.py
@@ -781,8 +781,18 @@ class SaturnFS(AbstractFileSystem, metaclass=_CachedTyped):  # pylint: disable=i
                     self.invalidate_cache(full_path(owner_name, path))
                 i += settings.OBJECT_STORAGE_MAX_LIST_COUNT
 
-    def rsync(self, source: str, destination: str, delete_missing: bool = False, **kwargs):
-        kwargs["fs"] = SaturnGenericFilesystem()
+    def rsync(
+        self,
+        source: str,
+        destination: str,
+        delete_missing: bool = False,
+        max_batch_workers: int = settings.SATURNFS_DEFAULT_MAX_WORKERS,
+        max_file_workers: int = 1,
+        **kwargs,
+    ):
+        kwargs["fs"] = SaturnGenericFilesystem(
+            max_batch_workers=max_batch_workers, max_file_workers=max_file_workers
+        )
         return rsync(source, destination, delete_missing=delete_missing, **kwargs)
 
     def list_uploads(

--- a/saturnfs/client/saturnfs.py
+++ b/saturnfs/client/saturnfs.py
@@ -789,11 +789,14 @@ class SaturnFS(AbstractFileSystem, metaclass=_CachedTyped):  # pylint: disable=i
         max_batch_workers: int = settings.SATURNFS_DEFAULT_MAX_WORKERS,
         max_file_workers: int = 1,
         **kwargs,
-    ):
+    ) -> None:
         kwargs["fs"] = SaturnGenericFilesystem(
             max_batch_workers=max_batch_workers, max_file_workers=max_file_workers
         )
-        return rsync(source, destination, delete_missing=delete_missing, **kwargs)
+        rsync(source, destination, delete_missing=delete_missing, **kwargs)
+        if destination.startswith(settings.SATURNFS_FILE_PREFIX):
+            self.invalidate_cache(destination)
+        return None
 
     def list_uploads(
         self, path: str, is_copy: Optional[bool] = None


### PR DESCRIPTION
<!-- What is this change, and why is it needed? -->

When using rsync, it is more likely to have many small files that need to be uploaded/downloaded. This can be quite slow with the current implementation, which is geared towards uploading large files quickly in parallel chunks.

Because SaturnFS was not written with the async implementation, fsspec's batching blocks on each file transfer until completion, so it does not actually run in batches at all. To get around this we can dispatch each file copy operation to a threadpool.