### PR TITLE
Client retries

### DIFF
--- a/saturnfs/client/object_storage.py
+++ b/saturnfs/client/object_storage.py
@@ -31,6 +31,7 @@ from saturnfs.schemas.upload import (
 )
 from saturnfs.schemas.usage import ObjectStorageUsageResults
 from saturnfs.utils import requests_session
+from urllib3 import Retry
 
 
 class ObjectStorageClient:
@@ -48,6 +49,7 @@ class ObjectStorageClient:
             retries=retries,
             backoff_factor=backoff_factor,
             status_forcelist=retry_statuses,
+            allowed_methods=["POST", *Retry.DEFAULT_ALLOWED_METHODS],
             headers={"Authorization": f"token {settings.SATURN_TOKEN}"},
         )
 

--- a/saturnfs/utils.py
+++ b/saturnfs/utils.py
@@ -37,7 +37,8 @@ def requests_session(
 ) -> Session:
     retry = Retry(total=retries, backoff_factor=backoff_factor, **kwargs)
     session = Session()
-    session.mount("http", HTTPAdapter(max_retries=retry))
+    session.mount("http://", HTTPAdapter(max_retries=retry))
+    session.mount("https://", HTTPAdapter(max_retries=retry))
     if headers:
         session.headers.update(headers)
     return session

--- a/saturnfs/utils.py
+++ b/saturnfs/utils.py
@@ -31,11 +31,12 @@ def byte_range_header(start: int, end: int) -> Dict[str, str]:
 
 def requests_session(
     retries: int = 10,
+    connect: int = 5,
     backoff_factor: float = 0.1,
     headers: Optional[Dict[str, str]] = None,
     **kwargs,
 ) -> Session:
-    retry = Retry(total=retries, backoff_factor=backoff_factor, **kwargs)
+    retry = Retry(total=retries, connect=connect, backoff_factor=backoff_factor, **kwargs)
     session = Session()
     session.mount("http://", HTTPAdapter(max_retries=retry))
     session.mount("https://", HTTPAdapter(max_retries=retry))


### PR DESCRIPTION
<!-- What is this change, and why is it needed? -->

Updating object storage client retries to correctly mount retry adapter. Failures on POST are typically retriable (e.g. failed to get lock), so should be included in the list of allowed methods for 409/423 status codes.