### PR TITLE
Validate upload-id

### DIFF
--- a/saturnfs/api/upload.py
+++ b/saturnfs/api/upload.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, Optional
 
 from requests import Session
 from saturnfs.api.base import BaseAPI
+from saturnfs.errors import SaturnError
 
 
 class UploadAPI(BaseAPI):
@@ -16,12 +17,16 @@ class UploadAPI(BaseAPI):
 
     @classmethod
     def complete(cls, session: Session, upload_id: str, data: Dict[str, Any]) -> None:
+        if "/" in upload_id:
+            raise SaturnError("Invalid upload ID")
         url = cls.make_url(upload_id)
         response = session.post(url, json=data)
         cls.check_error(response, 204)
 
     @classmethod
     def cancel(cls, session: Session, upload_id: str) -> None:
+        if "/" in upload_id:
+            raise SaturnError("Invalid upload ID")
         url = cls.make_url(upload_id)
         response = session.delete(url)
         cls.check_error(response, 204)
@@ -35,6 +40,8 @@ class UploadAPI(BaseAPI):
         last_part: Optional[int] = None,
         last_part_size: Optional[int] = None,
     ) -> Dict[str, Any]:
+        if "/" in upload_id:
+            raise SaturnError("Invalid upload ID")
         query_args = {
             "first_part": first_part,
             "last_part": last_part,


### PR DESCRIPTION
<!-- What is this change, and why is it needed? -->

Validate upload-id does not contain `/` before sending API request. Ensures error messages are sensible.